### PR TITLE
Add support for gradle 7.1.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/src/main/kotlin/com/github/sedovalx/gradle/aspectj/AjcTask.kt
+++ b/plugin/src/main/kotlin/com/github/sedovalx/gradle/aspectj/AjcTask.kt
@@ -11,6 +11,9 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.InputDirectory
 import java.io.File
 import java.io.IOException
 import java.net.URLClassLoader
@@ -23,11 +26,17 @@ open class AjcTask : DefaultTask() {
     }
 
     // Task properties
+    @Input
     lateinit var sourceSets: Set<SourceSet>
+    @Input
     lateinit var additionalAjcParams: List<String>
+    @Input
     lateinit var source: String
+    @Input
     lateinit var target: String
+    @Optional @InputDirectory
     var outputDir: File? = null
+    @Input
     var writeToLog: Boolean = false
 
     @TaskAction

--- a/plugin/src/main/kotlin/com/github/sedovalx/gradle/aspectj/AjcTask.kt
+++ b/plugin/src/main/kotlin/com/github/sedovalx/gradle/aspectj/AjcTask.kt
@@ -13,7 +13,8 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.Internal
 import java.io.File
 import java.io.IOException
 import java.net.URLClassLoader
@@ -26,7 +27,7 @@ open class AjcTask : DefaultTask() {
     }
 
     // Task properties
-    @Input
+    @Internal
     lateinit var sourceSets: Set<SourceSet>
     @Input
     lateinit var additionalAjcParams: List<String>
@@ -34,7 +35,7 @@ open class AjcTask : DefaultTask() {
     lateinit var source: String
     @Input
     lateinit var target: String
-    @Optional @InputDirectory
+    @Optional @OutputDirectory
     var outputDir: File? = null
     @Input
     var writeToLog: Boolean = false


### PR DESCRIPTION
According to #10 this plugin actualy doesn't support gradle 7.

This is related to some annotations, introduced in Gradle 7, which need to be added to `AjcTask.kt`.
This pull request should solve this problem.

I've tried running examples and it seems to work. 